### PR TITLE
Fix Demo: Instead of passing the path to the migrations assembly, pas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can find more detailed examples in *CSharpMongoMigrations.Demo* project.
 It's a really simple. You should create an instance of *MigrationRunner* class.
 
 ```csharp
-   var runner = new MigrationRunner("<mongoDb_connection_string>", "<database_name>", "<location_to_assembly_with_migrations>");
+   var runner = new MigrationRunner("<mongoDb_connection_string>", "<database_name>", "<full_name_of_assembly_with_migrations>");
 ```
 Then you can call *Up* or *Down* method to apply or downgrade migrations.
 

--- a/src/CSharpMongoMigrations.Demo/Runner.cs
+++ b/src/CSharpMongoMigrations.Demo/Runner.cs
@@ -6,7 +6,7 @@ namespace CSharpMongoMigrations.Demo
     {
         public static void Main(string[] args)
         {            
-            var runner = new MigrationRunner("mongodb://localhost:27017/TestMigrations", Assembly.GetExecutingAssembly().CodeBase);
+            var runner = new MigrationRunner("mongodb://localhost:27017/TestMigrations", Assembly.GetExecutingAssembly().FullName);
             runner.Up();
         }
     }


### PR DESCRIPTION
Passing the assembly full name instead of the assembly path works. Maybe we should think of a workaround in case you want to pass the path