### PR TITLE
Add IMigrationFactory that opens up for dependency injection in migrations

### DIFF
--- a/src/CSharpMongoMigrations.Demo/Runner.cs
+++ b/src/CSharpMongoMigrations.Demo/Runner.cs
@@ -6,7 +6,7 @@ namespace CSharpMongoMigrations.Demo
     {
         public static void Main(string[] args)
         {            
-            var runner = new MigrationRunner("mongodb://localhost:27017/TestMigrations", Assembly.GetExecutingAssembly().FullName);
+            var runner = new MigrationRunner("mongodb://localhost:27017/TestMigrations", Assembly.GetExecutingAssembly().FullName, new MigrationFactory());
             runner.Up();
         }
     }

--- a/src/CSharpMongoMigrations.Tests/AutoFixture.cs
+++ b/src/CSharpMongoMigrations.Tests/AutoFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 
 namespace CSharpMongoMigrations.Tests
 {

--- a/src/CSharpMongoMigrations.Tests/CSharpMongoMigrations.Tests.csproj
+++ b/src/CSharpMongoMigrations.Tests/CSharpMongoMigrations.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>

--- a/src/CSharpMongoMigrations.Tests/MigrationFactoryTests.cs
+++ b/src/CSharpMongoMigrations.Tests/MigrationFactoryTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using MongoDB.Driver;
+using Xunit;
+
+namespace CSharpMongoMigrations.Tests
+{
+    public class MigrationFactoryTests
+    {
+        private class MigrationStub : Migration
+        {
+            public IMongoDatabase Db
+            {
+                get { return Database; }
+            }
+
+            public override void Down()
+            {
+            }
+
+            public override void Up()
+            {
+            }
+        }
+
+        [Fact]
+        public void UseDatabaseFact()
+        {
+            // Arrange
+            var factory = new MigrationFactory();
+
+            // Act
+            var migration = factory.Create(typeof(MigrationStub));
+
+            // Assert
+            migration.Should().NotBe(null);
+            migration.Should().BeOfType<MigrationStub>();
+        }
+    }
+}

--- a/src/CSharpMongoMigrations.Tests/MigrationFactoryTests.cs
+++ b/src/CSharpMongoMigrations.Tests/MigrationFactoryTests.cs
@@ -23,7 +23,7 @@ namespace CSharpMongoMigrations.Tests
         }
 
         [Fact]
-        public void UseDatabaseFact()
+        public void UseActivatorToCreateFact()
         {
             // Arrange
             var factory = new MigrationFactory();

--- a/src/CSharpMongoMigrations.Tests/MigrationRunnerTests.cs
+++ b/src/CSharpMongoMigrations.Tests/MigrationRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using MongoDB.Driver;
+using Moq;
 using Xunit;
 
 namespace CSharpMongoMigrations.Tests
@@ -11,7 +12,7 @@ namespace CSharpMongoMigrations.Tests
         {
             Assert.Throws<NullReferenceException>(() =>
             {
-                var runner = new MigrationRunner((MongoUrl)null, "test");
+                var runner = new MigrationRunner((MongoUrl)null, "test", new MigrationFactory());
             });
         }
 
@@ -20,7 +21,16 @@ namespace CSharpMongoMigrations.Tests
         {
             Assert.Throws<MongoConfigurationException>(() =>
             {
-                var runner = new MigrationRunner("test", "test");
+                var runner = new MigrationRunner("test", "test", new MigrationFactory());
+            });
+        }
+
+        [Fact]
+        public void ShouldNotCreateMigrationRunnerWithNullFactory()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var runner = new MigrationRunner("mongodb://valid", "test", factory: null);
             });
         }
     }

--- a/src/CSharpMongoMigrations.Tests/Migrations/MigrationTests.cs
+++ b/src/CSharpMongoMigrations.Tests/Migrations/MigrationTests.cs
@@ -22,7 +22,7 @@ namespace CSharpMongoMigrations.Tests
         }
 
 
-        [Fact]        
+        [Fact]
         [Description("Check IDbMigration.UseDatabase method. It's used only for internal purpose.")]
         public void UseDatabaseFact()
         {

--- a/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
+++ b/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.6</TargetFrameworks>

--- a/src/CSharpMongoMigrations/MigrationFactory.cs
+++ b/src/CSharpMongoMigrations/MigrationFactory.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace CSharpMongoMigrations
+{
+    public sealed class MigrationFactory : IMigrationFactory
+    {
+        public IMigration Create(Type type)
+        {
+            return (IMigration)Activator.CreateInstance(type);
+        }
+    }
+
+    public interface IMigrationFactory
+    {
+        IMigration Create(Type type);
+    }
+}

--- a/src/CSharpMongoMigrations/MigrationLocator.cs
+++ b/src/CSharpMongoMigrations/MigrationLocator.cs
@@ -24,29 +24,31 @@ namespace CSharpMongoMigrations
     {
         private readonly Assembly _assembly;
         private readonly IMongoDatabase _database;
+        private readonly IMigrationFactory _factory;
 
-        public MigrationLocator(string assemblyName, IMongoDatabase database)
+        public MigrationLocator(string assemblyName, IMongoDatabase database, IMigrationFactory factory)
         {
             _assembly = Assembly.Load(new AssemblyName(assemblyName));
             _database = database;
+            _factory = factory ?? throw new ArgumentNullException(nameof(factory));
         }
 
         public IEnumerable<VersionedMigration> GetMigrations(MigrationVersion after, MigrationVersion before)
         {
             var migrations =
-                (
-                    from type in _assembly.GetTypes()
-                    where typeof(IMigration).GetTypeInfo().IsAssignableFrom(type) && !type.GetTypeInfo().IsAbstract
-                    let attribute = type.GetTypeInfo().GetCustomAttribute<MigrationAttribute>()
-                    where attribute != null && after.Version < attribute.Version && attribute.Version <= before.Version
-                    orderby attribute.Version
-                    select new { Migration = (IMigration)Activator.CreateInstance(type), Version = new MigrationVersion(attribute.Version, attribute.Description) }
-                ).ToList();
+            (
+                from type in _assembly.GetTypes()
+                where typeof(IMigration).GetTypeInfo().IsAssignableFrom(type) && !type.GetTypeInfo().IsAbstract
+                let attribute = type.GetTypeInfo().GetCustomAttribute<MigrationAttribute>()
+                where attribute != null && after.Version < attribute.Version && attribute.Version <= before.Version
+                orderby attribute.Version
+                select new { Migration = _factory.Create(type), Version = new MigrationVersion(attribute.Version, attribute.Description) }
+            ).ToList();
 
             foreach (var m in migrations)
                 ((IDbMigration)m.Migration).UseDatabase(_database);
 
-            return migrations.Select(x => new VersionedMigration(x.Migration, x.Version));                
+            return migrations.Select(x => new VersionedMigration(x.Migration, x.Version));
         }
     }
 }


### PR DESCRIPTION
Thanks for this simplistic migration tool!

Some times settings are necessary to provide context to migrations. Currently it's not possible to inject anything into Migrations. By replacing the default MigrationFactory with an implementation that uses a dependency injection container to construct the Migrations, CSharpMongoMigrations would become very flexible, without compromising the simplicity.

This PR should be a non-breaking change.

Let me know what you think!

/Joakim