### PR TITLE
MigrationLocator with assembly parameter

### DIFF
--- a/src/CSharpMongoMigrations.Tests/Extensions/MongoCollectionExtensionsTests.cs
+++ b/src/CSharpMongoMigrations.Tests/Extensions/MongoCollectionExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace CSharpMongoMigrations.Tests
             var document = new BsonDocument(new BsonElement("_id", Guid.NewGuid()));
             var mockCollection = new Mock<IMongoCollection<BsonDocument>>();
 
-            mockCollection.Setup(x => x.ReplaceOne(It.IsAny<FilterDefinition<BsonDocument>>(), document, It.IsAny<UpdateOptions>(), It.IsAny<CancellationToken>()));
+            mockCollection.Setup(x => x.ReplaceOne(It.IsAny<FilterDefinition<BsonDocument>>(), document, It.IsAny<ReplaceOptions>(), It.IsAny<CancellationToken>()));
                        
 
             // Act

--- a/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
+++ b/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.6</TargetFrameworks>
-    <Version>2.1.2</Version>
+    <Version>2.1.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">

--- a/src/CSharpMongoMigrations/Extensions/MongoCollectionExtensions.cs
+++ b/src/CSharpMongoMigrations/Extensions/MongoCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace CSharpMongoMigrations
         /// <param name="document">The desired document for updating.</param>
         public static void Update(this IMongoCollection<BsonDocument> collection, BsonDocument document)
         {
-            var idFilter = Builders<BsonDocument>.Filter.Eq("_id", document.GetValue("_id").AsGuid);            
+            var idFilter = Builders<BsonDocument>.Filter.Eq("_id", document.GetValue("_id"));            
             collection.ReplaceOne(idFilter, document);
         }
 


### PR DESCRIPTION
I needed a constructor for MigrationLocator accepting the Assembly containing the migrations. 
I wanted to use your code inside of a dotnet cli command. The assembly location (Assembly.Load()) you used did not work, because the migration assembly wasn't located in any path used for locating the assembly.