### PR TITLE
NuGet package version is obtained from csproj file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSharpMongoMigrations
 
-[![NuGet](https://img.shields.io/badge/nuget-2.2.0-blue.svg)](https://www.nuget.org/packages/CSharpMongoMigrations/)
+[![NuGet](https://img.shields.io/badge/nuget-2.3.0-blue.svg)](https://www.nuget.org/packages/CSharpMongoMigrations/)
 
 ## What is it?
 

--- a/src/CSharpMongoMigrations.nuspec
+++ b/src/CSharpMongoMigrations.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>CSharpMongoMigrations</id>
-    <version>2.2.0</version>
+    <version>$version$</version>
     <title>CSharpMongoMigrations</title>
     <authors>Rybalko Vladimir</authors>
     <owners>Rybalko Vladimir</owners>

--- a/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
+++ b/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.6</TargetFrameworks>
-    <Version>2.1.3</Version>
+    <Version>2.3.0</Version>
+    <NuspecProperties>version=$(Version)</NuspecProperties>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">

--- a/src/build_nuget.bat
+++ b/src/build_nuget.bat
@@ -1,2 +1,5 @@
+rem --
+rem -- We can force the version of build and NuGet package with '-p:version=', but it is better to update it in .csproj file
+rem --
 dotnet build -c Release
 dotnet pack CSharpMongoMigrations/CSharpMongoMigrations.csproj /p:NuspecFile=../CSharpMongoMigrations.nuspec --output ../


### PR DESCRIPTION
I did some changes in csproj and nuspec files to allow create a NuGet package with the same version defined in csproj file.

It will fix the issue with latest NuGet package version (2.2.0) and latest version of the code (2.1.3). This NuGet package contains the previous version 2.1.2.