### PR TITLE
Update to MongoDb.Driver 3.1.0

### DIFF
--- a/src/CSharpMongoMigrations.Demo/CSharpMongoMigrations.Demo.csproj
+++ b/src/CSharpMongoMigrations.Demo/CSharpMongoMigrations.Demo.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CSharpMongoMigrations.Tests/CSharpMongoMigrations.Tests.csproj
+++ b/src/CSharpMongoMigrations.Tests/CSharpMongoMigrations.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/src/CSharpMongoMigrations.Tests/Extensions/BsonDocumentExtensionsTests.cs
+++ b/src/CSharpMongoMigrations.Tests/Extensions/BsonDocumentExtensionsTests.cs
@@ -41,7 +41,6 @@ namespace CSharpMongoMigrations.Tests
             act.Should().Throw<Exception>();
         }
 
-
         [Fact]
         public void AddPropertyFact()
         {
@@ -57,6 +56,40 @@ namespace CSharpMongoMigrations.Tests
             // Assert
             element.Should().NotBeNull();
             element.Value.Should().Be(value);
+        }
+
+        [Fact]
+        public void AddPropertyGuidFact()
+        {
+            // Arrange
+            var name = AutoFixture.String();
+            var value = Guid.NewGuid();
+            var document = new BsonDocument();
+
+            // Act
+            document.AddProperty(name, value);
+            var element = document.GetElement(name);
+
+            // Assert
+            element.Should().NotBeNull();
+            element.Value.AsGuid.Should().Be(value);
+        }
+
+        [Fact]
+        public void AddPropertyGuidWithStandardGuidRepresentationFact()
+        {
+            // Arrange
+            var name = AutoFixture.String();
+            var value = Guid.NewGuid();
+            var document = new BsonDocument();
+
+            // Act
+            document.AddProperty(name, value, GuidRepresentation.Standard);
+            var element = document.GetElement(name);
+
+            // Assert
+            element.Should().NotBeNull();
+            element.Value.AsGuid.Should().Be(value);
         }
 
         [Fact]
@@ -76,7 +109,42 @@ namespace CSharpMongoMigrations.Tests
         }
 
         [Fact]
+        public void AddUniqueIdentifierWithStandardGuidRepresentationFact()
+        {
+            // Arrange
+            var value = Guid.NewGuid();
+            var document = new BsonDocument();
+            var guidRepresentation = GuidRepresentation.Standard;
+
+            // Act
+            document.AddUniqueIdentifier(value, guidRepresentation);
+            var element = document.GetElement("_id");
+
+            // Assert
+            element.Should().NotBeNull();
+            element.Value.AsGuid.Should().Be(value);
+        }
+
+        [Fact]
         public void ChangeValueFact()
+        {
+            // Arrange
+            var name = AutoFixture.String();
+            var oldValue = AutoFixture.Int();
+            var newValue = AutoFixture.Int();
+            var document = new BsonDocument(new BsonElement("_id", new BsonBinaryData(Guid.NewGuid(), GuidRepresentation.Standard)));
+
+            // Act
+            document.AddProperty(name, oldValue);
+            document.ChangeValue(name, newValue);
+            var result = document.GetValue(name);
+
+            // Assert
+            result.AsInt32.Should().Be(newValue);
+        }
+
+        [Fact]
+        public void ChangeValueGuidFact()
         {
             // Arrange
             var name = AutoFixture.String();
@@ -85,7 +153,26 @@ namespace CSharpMongoMigrations.Tests
             var document = new BsonDocument(new BsonElement("_id", new BsonBinaryData(Guid.NewGuid(), GuidRepresentation.Standard)));
 
             // Act
+            document.AddProperty(name, oldValue);
             document.ChangeValue(name, newValue);
+            var result = document.GetValue(name);
+
+            // Assert
+            result.AsGuid.Should().Be(newValue);
+        }
+
+        [Fact]
+        public void ChangeValueGuidWithStandardGuidRepresentationFact()
+        {
+            // Arrange
+            var name = AutoFixture.String();
+            var oldValue = Guid.NewGuid();
+            var newValue = Guid.NewGuid();
+            var document = new BsonDocument(new BsonElement("_id", new BsonBinaryData(Guid.NewGuid(), GuidRepresentation.Standard)));
+
+            // Act
+            document.AddProperty(name, oldValue);
+            document.ChangeValue(name, newValue, GuidRepresentation.Standard);
             var result = document.GetValue(name);
 
             // Assert

--- a/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
+++ b/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
  <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CSharpMongoMigrations/Extensions/BsonDocumentExtensions.cs
+++ b/src/CSharpMongoMigrations/Extensions/BsonDocumentExtensions.cs
@@ -45,7 +45,6 @@ namespace CSharpMongoMigrations
             document.Add(element);
         }
 
-
         /// <summary>
         /// Add the unique identifier to the document.
         /// </summary>
@@ -54,7 +53,22 @@ namespace CSharpMongoMigrations
         /// <remarks>Id is always a Guid value by convention.</remarks>
         public static void AddUniqueIdentifier(this BsonDocument document, Guid value)
         {
-            document.AddProperty("_id", value);
+            var id = new BsonBinaryData(value, GuidRepresentation.Standard);
+            document.AddProperty("_id", id);
+        }
+
+        /// <summary>
+        /// Add the unique identifier to the document.
+        /// </summary>
+        /// <param name="document">The target document.</param>
+        /// <param name="value">An unique identifier value.</param>
+        /// <param name="guidRepresentation">Represents the representation to use when converting a Guid to a BSON binary value.</param>
+        /// <remarks>Id is always a Guid value by convention.</remarks>
+        public static void AddUniqueIdentifier(this BsonDocument document, Guid value, GuidRepresentation guidRepresentation)
+        {
+
+            var id = new BsonBinaryData(value, guidRepresentation);
+            document.AddProperty("_id", id);
         }
 
         /// <summary>
@@ -69,6 +83,37 @@ namespace CSharpMongoMigrations
 
             document.Remove(property);
             document.Add(@new);
-        }        
+        }
+
+        /// <summary>
+        /// Change the property value.
+        /// </summary>
+        /// <param name="document">The target document.</param>
+        /// <param name="property">The desired property name.</param>
+        /// <param name="value"></param>
+        public static void ChangeValue(this BsonDocument document, string property, Guid value)
+        {
+            var newBsonBinaryData = new BsonBinaryData(value, GuidRepresentation.Standard);
+            var @new = new BsonElement(property, newBsonBinaryData);
+
+            document.Remove(property);
+            document.Add(@new);
+        }
+
+        /// <summary>
+        /// Change the property value.
+        /// </summary>
+        /// <param name="document">The target document.</param>
+        /// <param name="property">The desired property name.</param>
+        /// <param name="value"></param>
+        /// <param name="guidRepresentation">Represents the representation to use when converting a Guid to a BSON binary value.</param>
+        public static void ChangeValue(this BsonDocument document, string property, Guid value, GuidRepresentation guidRepresentation)
+        {
+            var newBsonBinaryData = new BsonBinaryData(value, guidRepresentation);
+            var @new = new BsonElement(property, newBsonBinaryData);
+
+            document.Remove(property);
+            document.Add(@new);
+        }
     }
 }

--- a/src/CSharpMongoMigrations/Extensions/BsonDocumentExtensions.cs
+++ b/src/CSharpMongoMigrations/Extensions/BsonDocumentExtensions.cs
@@ -46,6 +46,30 @@ namespace CSharpMongoMigrations
         }
 
         /// <summary>
+        /// Add new property to the document.
+        /// </summary>
+        /// <param name="document">The target document.</param>
+        /// <param name="property">The desired property name.</param>
+        /// <param name="value">The desired property value.</param>
+        public static void AddProperty(this BsonDocument document, string property, Guid value)
+        {
+            document.AddProperty(property, value, GuidRepresentation.Standard);
+        }
+
+        /// <summary>
+        /// Add new property to the document.
+        /// </summary>
+        /// <param name="document">The target document.</param>
+        /// <param name="property">The desired property name.</param>
+        /// <param name="value">The desired property value.</param>
+        /// <param name="guidRepresentation">Represents the representation to use when converting a Guid to a BSON binary value.</param>
+        public static void AddProperty(this BsonDocument document, string property, Guid value, GuidRepresentation guidRepresentation)
+        {
+            var element = new BsonBinaryData(value, guidRepresentation);
+            document.Add(property, element);
+        }
+
+        /// <summary>
         /// Add the unique identifier to the document.
         /// </summary>
         /// <param name="document">The target document.</param>
@@ -53,8 +77,7 @@ namespace CSharpMongoMigrations
         /// <remarks>Id is always a Guid value by convention.</remarks>
         public static void AddUniqueIdentifier(this BsonDocument document, Guid value)
         {
-            var id = new BsonBinaryData(value, GuidRepresentation.Standard);
-            document.AddProperty("_id", id);
+            document.AddUniqueIdentifier(value, GuidRepresentation.Standard);
         }
 
         /// <summary>
@@ -93,11 +116,7 @@ namespace CSharpMongoMigrations
         /// <param name="value"></param>
         public static void ChangeValue(this BsonDocument document, string property, Guid value)
         {
-            var newBsonBinaryData = new BsonBinaryData(value, GuidRepresentation.Standard);
-            var @new = new BsonElement(property, newBsonBinaryData);
-
-            document.Remove(property);
-            document.Add(@new);
+            document.ChangeValue(property, value, GuidRepresentation.Standard);
         }
 
         /// <summary>


### PR DESCRIPTION
- Update to MongoDb.Driver 3.1.0
- Modify "AddUniqueIdentifier" method to support BsonBinaryData to save Guid.
- Added an overloaded method of "AddUniqueIdentifier" to assign a unique identifier to a BSON document using a GUID, with an additional parameter for GUID representation.