### PR TITLE
Add BsonGuidRepresentation attribute to MigrationVersion.Id, and upda…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,6 +238,10 @@ _Pvt_Extensions
 GeneratedArtifacts/
 ModelManifest.xml
 
+# JetBrains Rider
+.idea/
+*.sln.iml
+
 # Paket dependency manager
 .paket/paket.exe
 

--- a/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
+++ b/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Version>2.5.1</Version>
     <NuspecProperties>version=$(Version)</NuspecProperties>
   </PropertyGroup>

--- a/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
+++ b/src/CSharpMongoMigrations/CSharpMongoMigrations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
     <Version>2.5.1</Version>
     <NuspecProperties>version=$(Version)</NuspecProperties>
   </PropertyGroup>

--- a/src/CSharpMongoMigrations/MigrationVersion.cs
+++ b/src/CSharpMongoMigrations/MigrationVersion.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace CSharpMongoMigrations
 {
@@ -24,6 +26,7 @@ namespace CSharpMongoMigrations
         /// <summary>
         /// The unique identifier of the current migration.
         /// </summary>
+        [BsonGuidRepresentation(GuidRepresentation.Standard)]
         public Guid Id { get; } = Guid.NewGuid();
 
         /// <summary>


### PR DESCRIPTION
See https://github.com/VladimirRybalko/CSharpMongoMigrations/issues/27

* Add `BsonGuidRepresentation` attribute to `MigrationVersion.Id`
* Updated target framework to net8.0 to match test and demo assembly

Tested with the [suggested workaround](https://github.com/VladimirRybalko/CSharpMongoMigrations/issues/27#issuecomment-2687475678) removed.